### PR TITLE
lm-api with no args behaves the same as lm-api --help

### DIFF
--- a/src/lm_api/query_api.py
+++ b/src/lm_api/query_api.py
@@ -218,6 +218,12 @@ def get_parser():
         action="store_true",
         help="verbose output",
     )
+
+    # if there are no args, print the help
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     return parser
 
 


### PR DESCRIPTION
This adds a catch to display the help if the user just runs `lm-api` without any arguments.