### PR TITLE
get rid of 'if verbose:' blocks by adding a log func

### DIFF
--- a/src/lm_api/query_api.py
+++ b/src/lm_api/query_api.py
@@ -243,7 +243,7 @@ def get_parser():
 def main(args):
 
     PROVIDERS = ["goose", "openai"]
-
+    log(f"args:\n\t{args}", verbose=False)
     input_id = Path(args.input_file)
     assert input_id.exists(), f"input file {str(input_id)} does not exist"
     output_dir = (
@@ -336,8 +336,8 @@ def main(args):
         out_path=output_dir,
         source_path=input_id,
     )
-
-    print(f"done, output file:\n\t{out_file_path}")
+    print("Done")
+    log(f"output file:\n\t{out_file_path.resolve()}", verbose=verbose)
 
 
 def run():

--- a/src/lm_api/query_api.py
+++ b/src/lm_api/query_api.py
@@ -34,6 +34,11 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
+def log(msg, verbose):
+    logger.info(msg)
+    if verbose:
+        print(msg)
+
 
 def query_terms(
     term_list,
@@ -64,15 +69,16 @@ def query_terms(
     :param bool verbose: verbose output (default: False)
     :return list: list of responses from the API
     """
-    if verbose:
-        print(f"querying {len(term_list)} terms")
+    log(f"querying {len(term_list)} terms", verbose)
+    log(f"prefix: {prefix}", False)
+    log(f"suffix: {suffix}", False)
+
     for term in tqdm(term_list, desc="querying terms", total=len(term_list)):
 
         time.sleep(random.random() * 2)
         query = f"{prefix} {term} {suffix}".strip()
         _query_token_count = int(len(query.split()) / 4)  # approx 4 tokens per word
-        if verbose:
-            print(f"querying {term}:\n\t{query}")
+        log(f"querying {term}:\n\t{query}", verbose)
 
         # query the API
         completion = openai.Completion.create(

--- a/src/lm_api/query_api.py
+++ b/src/lm_api/query_api.py
@@ -34,7 +34,14 @@ logging.basicConfig(
 
 logger = logging.getLogger(__name__)
 
-def log(msg, verbose):
+
+def log(msg: str, verbose=False):
+    """
+    log - log a message to the console and to the log file
+
+    :param str msg: message to log
+    :param bool verbose: verbose output (default: False)
+    """
     logger.info(msg)
     if verbose:
         print(msg)

--- a/src/lm_api/query_api.py
+++ b/src/lm_api/query_api.py
@@ -76,9 +76,9 @@ def query_terms(
     :param bool verbose: verbose output (default: False)
     :return list: list of responses from the API
     """
-    log(f"querying {len(term_list)} terms", verbose)
-    log(f"prefix: {prefix}", False)
-    log(f"suffix: {suffix}", False)
+    log(f"\nquerying {len(term_list)} terms", verbose=verbose)
+    log(f"prefix: {prefix}", verbose=False)
+    log(f"suffix: {suffix}", verbose=False)
 
     for term in tqdm(term_list, desc="querying terms", total=len(term_list)):
 


### PR DESCRIPTION
Repeating `print` and `logging.info` with the same string each time is cumbersome; fix this.